### PR TITLE
Revamp farm registration wizard and add device discovery manager

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,15 +39,16 @@
       <div class="row" style="justify-content:space-between;align-items:center">
         <h2 style="margin:0">
           Farm Registration
-          <span class="hint" tabindex="0" data-tip="Create a saved Farm profile. The flow opens as a conversational modal and collapses back to this summary once saved.">?</span>
+          <span class="hint" tabindex="0" data-tip="Guided setup to get the reTerminal online, capture the farm address, and map Rooms/Zones. We save as we go and collapse to a summary badge when complete.">?</span>
         </h2>
         <div class="row" style="gap:6px">
           <button id="btnLaunchFarm" type="button" class="primary">Register Farm</button>
-          <button id="btnEditFarm" type="button" class="ghost" style="display:none">Edit Farm</button>
+          <button id="btnEditFarm" type="button" class="ghost" style="display:none">Edit</button>
         </div>
       </div>
-      <p class="tiny" style="margin:8px 0 0;color:#475569">We'll ask one question at a time and sync to the controller when you finish.</p>
+      <p class="tiny" style="margin:8px 0 0;color:#475569">Conversational prompts, 1–3 taps each. We'll store the farm profile locally and at <code>/farm</code>.</p>
       <div id="farmBadge" class="farm-summary" style="margin-top:12px; display:none;"></div>
+      <button id="btnStartDeviceSetup" type="button" class="ghost" style="display:none;margin-top:12px">Start Device Setup</button>
     </section>
 
     <!-- Grow Rooms Panel -->
@@ -923,223 +924,85 @@
     <div class="farm-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="farmModalTitle">
       <button type="button" class="farm-modal__close" id="farmModalClose" aria-label="Close">×</button>
       <form id="farmWizardForm" novalidate>
-  <p class="tiny" id="farmModalProgress" aria-live="polite">Step 1 of 7</p>
-        <h2 id="farmModalTitle" style="margin:0 0 12px">Let's get your farm on file</h2>
+        <p class="tiny" id="farmModalProgress" aria-live="polite">Step 1 of 6</p>
+        <h2 id="farmModalTitle" style="margin:0 0 12px">Let’s get you online</h2>
         <div id="farmSteps">
-          <section class="farm-step" data-step="farm-name">
-            <p class="farm-question">What's the name of your farm?</p>
-            <input id="farmName" name="farmName" type="text" autocomplete="organization" placeholder="e.g., Bright Leaf Gardens" required>
-          </section>
-
-          <section class="farm-step" data-step="device-catalog">
-            <p class="farm-question">Add your main grow lights and controllers.</p>
-            <div class="farm-step__stack">
-              <input id="kbSearch" type="text" placeholder="Type to search (e.g., Gavita 1700e)" autocomplete="off">
-              <div class="tiny" style="color:#64748b">Results</div>
-              <ul id="kbResults" class="farm-kb-results" aria-live="polite"></ul>
-              <div class="tiny" style="color:#64748b">Selected</div>
-              <ul id="kbSelected" class="farm-kb-selected" aria-live="polite"></ul>
+          <section class="farm-step" data-step="connection-choice">
+            <p class="farm-question">Let’s get you online—are you connecting this reTerminal to Wi‑Fi or Ethernet today?</p>
+            <div class="chip-row" id="farmConnectionChoice" role="radiogroup" aria-label="Connection type">
+              <button type="button" class="chip-option" data-value="wifi">Wi‑Fi</button>
+              <button type="button" class="chip-option" data-value="ethernet">Ethernet</button>
             </div>
+            <p class="tiny" style="margin-top:8px;color:#475569">Switch anytime—Wi‑Fi walks you through SSID, password, and a connection test.</p>
           </section>
 
-          <section class="farm-step" data-step="branding">
-            <p class="farm-question">Branding: want us to match your website?</p>
+          <section class="farm-step" data-step="wifi-select">
+            <p class="farm-question">Great—let’s pick the Wi‑Fi network.</p>
             <div class="farm-step__stack">
               <div class="row" style="gap:6px;align-items:center;flex-wrap:wrap">
-                <input id="brand-url" type="url" inputmode="url" placeholder="https://example.com" style="min-width:280px">
-                <button id="brand-find" type="button" class="ghost">Find my brand</button>
-                <span id="brand-status" class="tiny" aria-live="polite"></span>
+                <button id="btnScanWifi" type="button" class="ghost">Scan again</button>
+                <span id="wifiScanStatus" class="tiny" aria-live="polite"></span>
+                <button id="btnManualSsid" type="button" class="ghost">Add hidden network</button>
               </div>
-              <div class="row" style="gap:8px;align-items:center">
-                <img id="brand-logo" alt="Brand logo" style="height:28px;display:none" />
-                <div id="brand-palette" class="row" style="gap:6px"></div>
-                <button id="brand-apply" type="button" class="primary">Apply theme</button>
-              </div>
-              <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
-                <label class="tiny">Primary <input id="brand-primary" type="color" value="#0D7D7D"></label>
-                <label class="tiny">Accent <input id="brand-accent" type="color" value="#64C7C7"></label>
-                <label class="tiny">Text <input id="brand-text" type="color" value="#0B1220"></label>
-                <label class="tiny">Surface <input id="brand-surface" type="color" value="#FFFFFF"></label>
-                <label class="tiny">Background <input id="brand-bg" type="color" value="#F7FAFA"></label>
-                <label class="tiny" style="display:flex;align-items:center;gap:6px">
-                  Logo height
-                  <input id="brand-logo-height" type="range" min="18" max="64" value="28" style="width:160px">
-                  <span id="brand-logo-height-val" class="tiny" aria-live="polite">28 px</span>
-                </label>
-                <button id="brand-reset" type="button" class="ghost" title="Reset to default theme">Reset</button>
-              </div>
-              <p class="tiny" style="color:#64748b">We extract a palette and logo from your website, apply it live, and save it to your Farm profile.</p>
+              <div id="wifiNetworkList" class="chip-grid" role="listbox" aria-label="Available Wi‑Fi networks"></div>
             </div>
           </section>
 
-          <section class="farm-step" data-step="env-equipment">
-            <p class="farm-question">Environmental equipment — counts and control methods.</p>
+          <section class="farm-step" data-step="wifi-password">
+            <p class="farm-question">Enter the password for <span id="wifiChosenSsid" class="inline-chip"></span>.</p>
             <div class="farm-step__stack">
-              <div class="farm-microform" data-kind="hvac">
-                <div class="tiny">HVAC units</div>
-                <label>How many? <input type="number" id="mf-hvac-count" min="0" value="0" style="width:80px"></label>
-                <div class="tiny" style="margin-top:6px">Control</div>
-                <div class="chip-row" id="mf-hvac-control" role="group" aria-label="HVAC control">
-                  <button type="button" class="chip-option" data-value="Thermostat">Thermostat</button>
-                  <button type="button" class="chip-option" data-value="Modbus/BACnet">Modbus/BACnet</button>
-                  <button type="button" class="chip-option" data-value="Relay">Relay</button>
-                  <button type="button" class="chip-option" data-value="Other">Other</button>
-                </div>
-                <div class="tiny" style="margin-top:6px">Energy</div>
-                <div class="chip-row" id="mf-hvac-energy" role="group" aria-label="HVAC metering">
-                  <button type="button" class="chip-option" data-value="Built-in">Built-in</button>
-                  <button type="button" class="chip-option" data-value="CT/branch">CT/branch</button>
-                  <button type="button" class="chip-option" data-value="None">None</button>
-                </div>
-              </div>
-              <hr>
-              <div class="farm-microform" data-kind="dehu">
-                <div class="tiny">Dehumidifiers</div>
-                <label>How many? <input type="number" id="mf-dehu-count" min="0" value="0" style="width:80px"></label>
-                <div class="tiny" style="margin-top:6px">Control</div>
-                <div class="chip-row" id="mf-dehu-control">
-                  <button type="button" class="chip-option" data-value="Smart plug">Smart plug</button>
-                  <button type="button" class="chip-option" data-value="Relay">Relay</button>
-                  <button type="button" class="chip-option" data-value="Other">Other</button>
-                </div>
-                <div class="tiny" style="margin-top:6px">Energy</div>
-                <div class="chip-row" id="mf-dehu-energy">
-                  <button type="button" class="chip-option" data-value="Built-in">Built-in</button>
-                  <button type="button" class="chip-option" data-value="CT/branch">CT/branch</button>
-                  <button type="button" class="chip-option" data-value="None">None</button>
-                </div>
-              </div>
-              <hr>
-              <div class="farm-microform" data-kind="fans">
-                <div class="tiny">Fans</div>
-                <label>How many? <input type="number" id="mf-fans-count" min="0" value="0" style="width:80px"></label>
-                <div class="tiny" style="margin-top:6px">Control</div>
-                <div class="chip-row" id="mf-fans-control">
-                  <button type="button" class="chip-option" data-value="Smart plug">Smart plug</button>
-                  <button type="button" class="chip-option" data-value="0-10V/VFD">0-10V/VFD</button>
-                  <button type="button" class="chip-option" data-value="Other">Other</button>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section class="farm-step" data-step="sensor-pick">
-            <p class="farm-question">Pick sensor categories and default locations.</p>
-            <div class="farm-step__stack">
-              <div class="tiny">Categories</div>
-              <div id="sensorCats" class="chip-row" role="group" aria-label="Sensor categories">
-                <label class="chip-option"><input type="checkbox" value="tempRh"><span>Temp/RH</span></label>
-                <label class="chip-option"><input type="checkbox" value="co2"><span>CO₂</span></label>
-                <label class="chip-option"><input type="checkbox" value="vpd"><span>Dewpoint/VPD</span></label>
-                <label class="chip-option"><input type="checkbox" value="ppfd"><span>Light/PPFD</span></label>
-                <label class="chip-option"><input type="checkbox" value="energy"><span>Energy/Power</span></label>
-                <label class="chip-option"><input type="checkbox" value="water"><span>Water</span></label>
-              </div>
-              <div class="tiny" style="margin-top:6px">Default location</div>
-              <div id="sensorLocs" class="chip-row" role="group" aria-label="Sensor locations">
-                <button type="button" class="chip-option" data-value="Room">Room</button>
-                <button type="button" class="chip-option" data-value="Zone">Zone</button>
-                <button type="button" class="chip-option" data-value="Canopy">Canopy</button>
-                <button type="button" class="chip-option" data-value="Intake">Intake</button>
-                <button type="button" class="chip-option" data-value="Exhaust">Exhaust</button>
-                <button type="button" class="chip-option" data-value="Outdoor">Outdoor</button>
-              </div>
-            </div>
-          </section>
-
-          <section class="farm-step" data-step="connectivity">
-            <p class="farm-question">Connectivity and security.</p>
-            <div class="farm-step__stack">
-              <div>
-                <div class="tiny">Local hub present?</div>
-                <div id="hubPresent" class="chip-row" role="group">
-                  <button type="button" class="chip-option" data-value="yes">Yes</button>
-                  <button type="button" class="chip-option" data-value="no">No</button>
-                </div>
-                <div class="row" style="gap:6px;margin-top:6px">
-                  <label>Hub host/IP <input id="hubHost" type="text" placeholder="e.g., greach-pi or 100.65.187.59"></label>
-                  <label>Node-RED? <select id="hubNodeRed"><option value="unknown">Unknown</option><option value="yes">Yes</option><option value="no">No</option></select></label>
-                  <button id="hubTest" type="button" class="ghost">Test connection</button>
-                  <span id="hubTestStatus" class="tiny" aria-live="polite"></span>
-                </div>
-                <details style="margin-top:6px">
-                  <summary class="tiny">How to connect over VPN (VNC/SSH)</summary>
-                  <div class="tiny" style="color:#475569; margin-top:6px">
-                    1) Ensure Tailscale is running on both your Mac and the reTerminal.<br>
-                    2) Find the Pi's VPN IP: <code>tailscale ip -4</code> (example: 100.65.187.59).<br>
-                    3) VNC: Connect in VNC Viewer to that IP and log in as <code>greenreach</code> (password: <code>greenreach</code>).<br>
-                    4) SSH: <code>ssh greenreach@100.65.187.59</code> (password: <code>greenreach</code>).<br>
-                    5) API Forwarder health: <code>curl -s http://100.65.187.59:8089/healthz</code>.<br>
-                    If the probe fails, try the "Test connection" button above with <code>http://100.65.187.59:8089</code>.
-                  </div>
-                </details>
-              </div>
-              <div style="margin-top:8px">
-                <div class="tiny">Cloud tenant</div>
-                <input id="cloudTenant" type="text" placeholder="e.g., Azure tenant ID (optional)">
-              </div>
-              <div style="margin-top:8px">
-                <div class="tiny">Roles</div>
-                <div id="roleList" class="farm-role-list"></div>
-                <div class="row" style="gap:6px;margin-top:6px">
-                  <input id="roleName" type="text" placeholder="Name" style="width:160px">
-                  <input id="roleEmail" type="email" placeholder="Email" style="width:200px">
-                  <select id="roleType"><option>Admin</option><option>Operator</option><option>Viewer</option></select>
-                  <button id="addRole" type="button" class="ghost">Add</button>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section class="farm-step" data-step="locations">
-            <p class="farm-question">Where do you grow? Add each site, room, or greenhouse name.</p>
-            <div class="farm-step__stack">
-              <div class="row" style="gap:6px">
-                <input id="farmLocation" type="text" placeholder="e.g., North Greenhouse">
-                <button id="addFarmLocation" type="button" class="ghost">Add</button>
-              </div>
-              <ul id="farmLocationList" class="farm-chips" aria-live="polite"></ul>
-              <p class="tiny" style="color:#64748b">Add at least one location so schedules and groups know where to pull labels.</p>
-            </div>
-          </section>
-
-          <section class="farm-step" data-step="contact-name">
-            <p class="farm-question">Who should we contact about this farm?</p>
-            <input id="farmContact" type="text" autocomplete="name" placeholder="e.g., Jordan Lee" required>
-          </section>
-
-          <section class="farm-step" data-step="contact-email">
-            <p class="farm-question">What's the best email for them?</p>
-            <input id="farmContactEmail" type="email" autocomplete="email" placeholder="name@example.com" required>
-          </section>
-
-          <section class="farm-step" data-step="contact-phone">
-            <p class="farm-question">Want to add a phone number? (optional)</p>
-            <input id="farmContactPhone" type="tel" autocomplete="tel" placeholder="e.g., +1 (555) 123-4567">
-          </section>
-
-          <section class="farm-step" data-step="crops">
-            <p class="farm-question">What crops are you focusing on right now?</p>
-            <fieldset class="farm-crop-grid">
-              <label><input type="checkbox" value="Greens" class="farmCropOption">Greens</label>
-              <label><input type="checkbox" value="Herbs" class="farmCropOption">Herbs</label>
-              <label><input type="checkbox" value="Strawberries" class="farmCropOption">Strawberries</label>
-              <label><input type="checkbox" value="Tomatoes" class="farmCropOption">Tomatoes</label>
-              <label class="farm-crop-other">
-                <input type="checkbox" value="Other" class="farmCropOption" id="farmCropOtherToggle">Other
-                <input id="farmCropOtherText" type="text" placeholder="Tell us what's growing" style="display:none">
+              <input id="wifiPassword" type="password" autocomplete="new-password" placeholder="Wi‑Fi password" required>
+              <label class="tiny" style="display:flex;align-items:center;gap:6px"><input id="wifiShowPassword" type="checkbox">Show password</label>
+              <label class="tiny" style="display:flex;align-items:center;gap:6px">
+                <input id="wifiReuseDevices" type="checkbox" checked>
+                Use this network for device discovery
               </label>
-            </fieldset>
-            <p class="tiny" style="color:#64748b">Pick everything that applies. We'll surface these in recipes later.</p>
+            </div>
+          </section>
+
+          <section class="farm-step" data-step="wifi-test">
+            <p class="farm-question">Testing that connection…</p>
+            <div class="farm-step__stack">
+              <button id="btnTestWifi" type="button" class="primary">Test connection</button>
+              <div id="wifiTestStatus" class="farm-review" aria-live="polite"></div>
+            </div>
+          </section>
+
+          <section class="farm-step" data-step="location">
+            <p class="farm-question">Where is this farm?</p>
+            <div class="farm-step__stack">
+              <input id="farmName" name="farmName" type="text" autocomplete="organization" placeholder="Farm name" required>
+              <input id="farmAddress" type="text" autocomplete="street-address" placeholder="Street address">
+              <div class="row" style="gap:6px;flex-wrap:wrap">
+                <input id="farmCity" type="text" autocomplete="address-level2" placeholder="City">
+                <input id="farmState" type="text" autocomplete="address-level1" placeholder="State / Province" style="max-width:140px">
+                <input id="farmPostal" type="text" autocomplete="postal-code" placeholder="Postal code" style="max-width:140px">
+              </div>
+              <label class="tiny" style="display:flex;align-items:center;gap:6px">
+                Timezone
+                <select id="farmTimezone" style="min-width:200px"></select>
+              </label>
+            </div>
+          </section>
+
+          <section class="farm-step" data-step="spaces">
+            <p class="farm-question">Add your spaces—rooms first, then zones within each room.</p>
+            <div class="farm-step__stack">
+              <div class="row" style="gap:6px;flex-wrap:wrap">
+                <input id="newRoomName" type="text" placeholder="Room name (e.g., Flower A)">
+                <button id="btnAddRoom" type="button" class="ghost">Add room</button>
+              </div>
+              <div id="roomsEditor" class="farm-spaces" aria-live="polite"></div>
+            </div>
           </section>
 
           <section class="farm-step" data-step="review">
-            <p class="farm-question">Here's what we'll save. Feel free to go back if something needs editing.</p>
-            <div id="farmReview" class="farm-review"></div>
+            <p class="farm-question">Farm · Rooms · Zones — ready to save?</p>
+            <div class="farm-review" id="farmReview"></div>
           </section>
         </div>
 
-        <div class="row farm-modal__footer" style="justify-content:space-between;margin-top:18px">
+        <div class="row" style="justify-content:space-between;margin-top:18px">
           <button id="farmPrev" type="button" class="ghost">Back</button>
           <div class="row" style="gap:8px">
             <button id="farmNext" type="button" class="primary">Next</button>
@@ -1147,6 +1010,33 @@
           </div>
         </div>
       </form>
+    </div>
+  </div>
+
+  <div id="deviceManager" class="device-manager" aria-hidden="true">
+    <div class="device-manager__backdrop" id="deviceManagerBackdrop"></div>
+    <div class="device-manager__window" role="dialog" aria-modal="true" aria-labelledby="deviceManagerTitle">
+      <header class="device-manager__header">
+        <div>
+          <h2 id="deviceManagerTitle">Device Manager</h2>
+          <p class="tiny" id="deviceManagerSubtitle">Scan Wi‑Fi, BLE, and MQTT sources to bring devices into the farm.</p>
+        </div>
+        <button type="button" id="deviceManagerClose" class="ghost" aria-label="Close">×</button>
+      </header>
+      <div class="device-manager__toolbar">
+        <button id="btnRunDiscovery" type="button" class="primary">🔍 Run discovery</button>
+        <span id="discoveryStatus" class="tiny" aria-live="polite"></span>
+        <div class="chip-row" role="tablist" aria-label="Discovery filters">
+          <button type="button" class="chip-option" data-filter="all" aria-selected="true">All</button>
+          <button type="button" class="chip-option" data-filter="added">Added</button>
+          <button type="button" class="chip-option" data-filter="ignored">Ignored</button>
+        </div>
+      </div>
+      <div id="deviceDiscoveryResults" class="device-manager__results" aria-live="polite"></div>
+      <footer class="device-manager__footer">
+        <div id="deviceManagerSummary" class="tiny"></div>
+        <button id="btnOpenAutomation" type="button" class="ghost">Open Automation Card</button>
+      </footer>
     </div>
   </div>
 

--- a/public/styles.charlie.css
+++ b/public/styles.charlie.css
@@ -446,6 +446,50 @@ input[type="checkbox"] {
   font-size: 0.875rem;
 }
 
+.farm-spaces {
+  display: grid;
+  gap: 12px;
+}
+
+.farm-room-card {
+  border: 1px solid var(--gr-border, #E5E7EB);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: var(--gr-bg, #F8FAFC);
+  box-shadow: var(--shadow, var(--gr-shadow));
+}
+
+.farm-room-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.farm-room-card__zones {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.farm-room-card__zones .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.farm-room-card__zones button {
+  background: none;
+  border: none;
+  color: var(--medium);
+  cursor: pointer;
+  font-size: 0.7rem;
+}
+
+.farm-zone-input {
+  min-width: 160px;
+}
+
 /* Branding preview chips */
 .color-chip {
   width: 20px;
@@ -790,6 +834,31 @@ input[type="checkbox"] {
 
 .chip-option:hover {
   background: var(--gr-bg, #F9FAFB);
+}
+
+.chip-option.is-active,
+.chip-row .chip-option.is-active,
+.chip-row .chip-option[data-active] {
+  background: var(--gr-primary-soft, rgba(13,125,125,0.12));
+  border-color: var(--gr-primary, #0D7D7D);
+  color: var(--gr-primary, #0D7D7D);
+}
+
+.chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.inline-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  background: var(--gr-primary-soft, rgba(13,125,125,0.12));
+  border-radius: 999px;
+  font-size: 0.85em;
+  color: var(--gr-primary, #0D7D7D);
 }
 
 .chip-option input[type="radio"]:checked + span {
@@ -1165,3 +1234,167 @@ input[type="range"]#grd {
 .toast--warn .toast-title{color:#92400e}
 .toast--error{border-color:#fecaca}
 .toast--error .toast-title{color:#991b1b}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--gr-border, #E5E7EB);
+  background: var(--gr-surface, #fff);
+  color: var(--medium);
+}
+
+.badge--success {
+  background: #dcfce7;
+  border-color: #4ade80;
+  color: #166534;
+}
+
+.badge--warn {
+  background: #fef3c7;
+  border-color: #facc15;
+  color: #92400e;
+}
+
+.badge--muted {
+  background: #e2e8f0;
+  border-color: #cbd5f5;
+  color: #475569;
+}
+
+.badge--protocol {
+  background: #e0f2fe;
+  border-color: #38bdf8;
+  color: #075985;
+}
+
+.device-manager {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 1000;
+}
+
+.device-manager[aria-hidden="false"] {
+  display: flex;
+}
+
+.device-manager__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.device-manager__window {
+  position: relative;
+  margin: auto;
+  width: min(960px, 92vw);
+  max-height: 90vh;
+  background: var(--gr-surface, #fff);
+  border-radius: 16px;
+  box-shadow: var(--gr-shadow-lg, var(--shadow-lg));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.device-manager__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--gr-border, #E5E7EB);
+  gap: 12px;
+}
+
+.device-manager__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--gr-border, #E5E7EB);
+}
+
+.device-manager__results {
+  padding: 16px 20px;
+  overflow-y: auto;
+  flex: 1;
+  display: grid;
+  gap: 12px;
+}
+
+.device-manager__card {
+  border: 1px solid var(--gr-border, #E5E7EB);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--gr-surface, #fff);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: var(--shadow, var(--gr-shadow));
+}
+
+.device-manager__card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.device-manager__name {
+  font-weight: 600;
+}
+
+.device-manager__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.device-manager__card-body {
+  display: grid;
+  gap: 4px;
+}
+
+.device-manager__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.device-manager__assignment {
+  margin-top: 4px;
+}
+
+.device-manager__assign-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-end;
+  background: var(--gr-bg, #f8fafc);
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid var(--gr-border, #E5E7EB);
+}
+
+.device-manager__assign-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.75rem;
+  color: var(--medium);
+}
+
+.device-manager__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 20px;
+  border-top: 1px solid var(--gr-border, #E5E7EB);
+  background: var(--gr-bg, #F7FAFA);
+}


### PR DESCRIPTION
## Summary
- replace the farm registration wizard with a conversational flow that covers Wi-Fi/Ethernet setup, farm location metadata, and room/zone capture while persisting to farm.json and localStorage
- add a dedicated Device Manager window that runs discovery across Wi-Fi, BLE, and MQTT sources, supports room/zone assignments, and updates the dashboard UI styles
- expose server endpoints for Wi-Fi scanning/testing and device discovery to support the new setup experience

## Testing
- npm run start:local *(fails: missing dependency `nedb-promises` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db0858e884832bb717d4132c39a92a