### PR TITLE
Normalize setup wizard API responses and remove duplicate routes

### DIFF
--- a/SETUP_WIZARD_SYSTEM.md
+++ b/SETUP_WIZARD_SYSTEM.md
@@ -59,6 +59,17 @@ The Light Engine Charlie now includes a comprehensive **Setup Wizard System** th
 
 ## 🚀 API Endpoints
 
+All setup-wizard endpoints respond with a JSON payload shaped as:
+
+```json
+{
+  "success": true,
+  "...": "Endpoint-specific data"
+}
+```
+
+On errors the `success` flag is `false` and an `error` message is included.
+
 ### Get Available Wizards
 ```http
 GET /setup/wizards

--- a/server-charlie.js
+++ b/server-charlie.js
@@ -3975,39 +3975,7 @@ app.post('/api/device/:deviceId/dimming', async (req, res) => {
   });
 });
 
-// Express error handling middleware - must be last
-app.use((error, req, res, next) => {
-  console.error('❌ Express Error Handler:', error);
-  console.error('Stack:', error.stack);
-  console.error('Request URL:', req.url);
-  console.error('Request Method:', req.method);
-  
-  // Don't expose internal errors to client in production
-  const isDev = process.env.NODE_ENV !== 'production';
-  
-  res.status(error.status || 500).json({
-    error: 'Internal Server Error',
-    message: isDev ? error.message : 'Something went wrong',
-    requestId: req.headers['x-request-id'] || Date.now().toString(),
-    timestamp: new Date().toISOString()
-  });
-});
-
 // Setup wizard endpoints - triggered when devices are identified
-app.get('/setup/wizards/:wizardId', async (req, res) => {
-  const { wizardId } = req.params;
-  try {
-    const wizard = await getSetupWizard(wizardId);
-    if (!wizard) {
-      return res.status(404).json({ error: 'Wizard not found' });
-    }
-    res.json(wizard);
-  } catch (error) {
-    console.error('Failed to load setup wizard:', error);
-    res.status(500).json({ error: 'Failed to load setup wizard' });
-  }
-});
-
 // Get all available setup wizards
 app.get('/setup/wizards', async (req, res) => {
   try {
@@ -4623,107 +4591,30 @@ app.post('/setup/wizards/:wizardId/execute-validated', async (req, res) => {
 app.use((req, res) => {
   console.warn(`⚠️  404 Not Found: ${req.method} ${req.url}`);
   res.status(404).json({
+    success: false,
     error: 'Not Found',
     message: `Route ${req.method} ${req.url} not found`,
     timestamp: new Date().toISOString()
   });
 });
 
-// Get wizard execution status
-app.get('/setup/wizards/:wizardId/status', async (req, res) => {
-  try {
-    const { wizardId } = req.params;
-    const status = await getWizardStatus(wizardId);
-    
-    if (!status.exists) {
-      return res.status(404).json({
-        success: false,
-        error: 'Wizard not found or never started'
-      });
-    }
-    
-    res.json({
-      success: true,
-      status
-    });
-  } catch (error) {
-    console.error(`Error getting wizard status ${req.params.wizardId}:`, error);
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
-  }
-});
+// Express error handling middleware - must be last
+app.use((error, req, res, next) => {
+  console.error('❌ Express Error Handler:', error);
+  console.error('Stack:', error.stack);
+  console.error('Request URL:', req.url);
+  console.error('Request Method:', req.method);
 
-// Reset wizard state (useful for testing)
-app.delete('/setup/wizards/:wizardId', async (req, res) => {
-  try {
-    const { wizardId } = req.params;
-    wizardStates.delete(wizardId);
-    console.log(`🗑️ Reset wizard state for ${wizardId}`);
-    res.json({
-      success: true,
-      message: `Wizard ${wizardId} state reset`
-    });
-  } catch (error) {
-    console.error(`Error resetting wizard ${req.params.wizardId}:`, error);
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
-  }
-});
+  // Don't expose internal errors to client in production
+  const isDev = process.env.NODE_ENV !== 'production';
 
-// Automatically suggest wizards for discovered devices
-app.post('/discovery/suggest-wizards', async (req, res) => {
-  try {
-    const { devices } = req.body;
-    if (!Array.isArray(devices)) {
-      return res.status(400).json({
-        success: false,
-        error: 'devices array is required'
-      });
-    }
-    
-    const suggestions = [];
-    
-    for (const device of devices) {
-      // Find applicable wizards for this device type
-      const applicableWizards = Object.values(SETUP_WIZARDS).filter(wizard => 
-        wizard.targetDevices.includes(device.type) || 
-        device.services?.some(service => wizard.targetDevices.includes(service))
-      );
-      
-      if (applicableWizards.length > 0) {
-        suggestions.push({
-          device: {
-            ip: device.ip,
-            hostname: device.hostname,
-            type: device.type,
-            services: device.services
-          },
-          recommendedWizards: applicableWizards.map(w => ({
-            id: w.id,
-            name: w.name,
-            description: w.description,
-            confidence: calculateWizardConfidence(device, w)
-          })).sort((a, b) => b.confidence - a.confidence)
-        });
-      }
-    }
-    
-    res.json({
-      success: true,
-      suggestions
-    });
-    
-  } catch (error) {
-    console.error('Error suggesting wizards:', error);
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
-  }
+  res.status(error.status || 500).json({
+    success: false,
+    error: 'Internal Server Error',
+    message: isDev ? error.message : 'Something went wrong',
+    requestId: req.headers['x-request-id'] || Date.now().toString(),
+    timestamp: new Date().toISOString()
+  });
 });
 
 // Start the server after all routes are defined

--- a/test-advanced-wizards.cjs
+++ b/test-advanced-wizards.cjs
@@ -139,6 +139,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${validatedResponse.status}`);
+    console.log(`Success: ${validatedResponse.data.success}`);
     if (validatedResponse.data.result) {
       console.log(`Success: ${validatedResponse.data.result.success}`);
       if (validatedResponse.data.result.message) {
@@ -159,6 +160,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${invalidResponse.status}`);
+    console.log(`Success: ${invalidResponse.data.success}`);
     if (invalidResponse.data.errors) {
       console.log(`Validation errors: ${invalidResponse.data.errors.length}`);
       invalidResponse.data.errors.forEach(error => {
@@ -174,6 +176,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${bulkResponse.status}`);
+    console.log(`Success: ${bulkResponse.data.success}`);
     if (bulkResponse.data.result) {
       const result = bulkResponse.data.result;
       console.log(`Operation: ${result.operation}`);
@@ -196,6 +199,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${mqttResponse.status}`);
+    console.log(`Success: ${mqttResponse.data.success}`);
     if (mqttResponse.data.result) {
       console.log(`Success: ${mqttResponse.data.result.success}`);
       if (mqttResponse.data.result.message) {
@@ -218,6 +222,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${topicResponse.status}`);
+    console.log(`Success: ${topicResponse.data.success}`);
     if (topicResponse.data.result) {
       console.log(`Success: ${topicResponse.data.result.success}`);
       if (topicResponse.data.result.data?.discoveredTopics) {

--- a/test-wizard-system.js
+++ b/test-wizard-system.js
@@ -52,8 +52,9 @@ async function testWizardSystem() {
     console.log('📋 Test 1: Getting all available wizards...');
     const wizardsResponse = await makeRequest('GET', '/setup/wizards');
     console.log(`Status: ${wizardsResponse.status}`);
+    console.log(`Success: ${wizardsResponse.data.success}`);
     console.log('Available wizards:');
-    if (wizardsResponse.data.wizards) {
+    if (wizardsResponse.data.success && wizardsResponse.data.wizards) {
       wizardsResponse.data.wizards.forEach(w => {
         console.log(`  - ${w.id}: ${w.name} (${w.stepCount} steps)`);
       });
@@ -64,7 +65,8 @@ async function testWizardSystem() {
     console.log('🎯 Test 2: Getting MQTT wizard definition...');
     const mqttWizardResponse = await makeRequest('GET', '/setup/wizards/mqtt-setup');
     console.log(`Status: ${mqttWizardResponse.status}`);
-    if (mqttWizardResponse.data.wizard) {
+    console.log(`Success: ${mqttWizardResponse.data.success}`);
+    if (mqttWizardResponse.data.success && mqttWizardResponse.data.wizard) {
       const wizard = mqttWizardResponse.data.wizard;
       console.log(`Wizard: ${wizard.name}`);
       console.log(`Description: ${wizard.description}`);
@@ -89,6 +91,7 @@ async function testWizardSystem() {
       data: stepData
     });
     console.log(`Status: ${executeResponse.status}`);
+    console.log(`Success: ${executeResponse.data.success}`);
     if (executeResponse.data.result) {
       console.log(`Success: ${executeResponse.data.result.success}`);
       console.log(`Next step: ${executeResponse.data.result.nextStep}`);
@@ -99,7 +102,8 @@ async function testWizardSystem() {
     console.log('📊 Test 4: Checking wizard execution status...');
     const statusResponse = await makeRequest('GET', '/setup/wizards/mqtt-setup/status');
     console.log(`Status: ${statusResponse.status}`);
-    if (statusResponse.data.status) {
+    console.log(`Success: ${statusResponse.data.success}`);
+    if (statusResponse.data.success && statusResponse.data.status) {
       const status = statusResponse.data.status;
       console.log(`Progress: ${status.progress}% (${status.currentStep}/${status.totalSteps})`);
       console.log(`Completed: ${status.completed}`);
@@ -128,7 +132,8 @@ async function testWizardSystem() {
       devices: testDevices
     });
     console.log(`Status: ${suggestResponse.status}`);
-    if (suggestResponse.data.suggestions) {
+    console.log(`Success: ${suggestResponse.data.success}`);
+    if (suggestResponse.data.success && suggestResponse.data.suggestions) {
       console.log('Wizard suggestions:');
       suggestResponse.data.suggestions.forEach(suggestion => {
         console.log(`  Device: ${suggestion.device.ip} (${suggestion.device.type})`);


### PR DESCRIPTION
## Summary
- remove redundant setup wizard route registrations and ensure all wizard APIs are defined before the 404 handler
- normalize setup wizard and discovery responses to consistently include a success flag and propagate that flag in documentation and test scripts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e07d061530832ba5c933cd32c6584a