### PR TITLE
Fix Kasa wizard import interop and add regression test

### DIFF
--- a/server-charlie.js
+++ b/server-charlie.js
@@ -3358,7 +3358,19 @@ async function executeKasaWizardStep(stepId, data) {
       console.log(`🔍 Discovering Kasa devices (timeout: ${data.discoveryTimeout}s)`);
       
       try {
-        const { Client } = await import('tplink-smarthome-api');
+        const kasaModule = await import('tplink-smarthome-api');
+        const Client = kasaModule.Client ?? kasaModule.default?.Client ?? kasaModule.default;
+
+        if (typeof Client !== 'function') {
+          const message = 'tplink-smarthome-api Client constructor not available';
+          console.error(message);
+          return {
+            success: false,
+            error: message,
+            data: {}
+          };
+        }
+
         const client = new Client();
         const kasaDevices = [];
         

--- a/test-advanced-wizards.cjs
+++ b/test-advanced-wizards.cjs
@@ -232,6 +232,29 @@ async function testAdvancedWizardSystem() {
     }
     console.log('');
 
+    // Test 9: Kasa auto-discovery regression (ensures Client constructor is available)
+    console.log('🔌 Test 9: Testing Kasa auto-discovery regression...');
+    const kasaDiscoveryResponse = await makeRequest('POST', '/setup/wizards/kasa-setup/execute', {
+      stepId: 'device-discovery',
+      data: {
+        discoveryTimeout: 1
+      }
+    });
+
+    console.log(`Status: ${kasaDiscoveryResponse.status}`);
+    if (kasaDiscoveryResponse.data?.result) {
+      const kasaResult = kasaDiscoveryResponse.data.result;
+      console.log(`Success: ${kasaResult.success}`);
+      if (kasaResult.message) {
+        console.log(`Message: ${kasaResult.message}`);
+      }
+      if (kasaResult.success === false) {
+        throw new Error(`Kasa discovery step failed: ${kasaResult.error || 'Unknown error'}`);
+      }
+    } else {
+      throw new Error('Kasa discovery response did not include a result payload');
+    }
+
     console.log('✅ All advanced wizard system tests completed successfully!');
     console.log('\n🎯 Advanced Features Tested:');
     console.log('  ✅ Wizard templates and recommendations');
@@ -240,6 +263,7 @@ async function testAdvancedWizardSystem() {
     console.log('  ✅ Bulk wizard operations');
     console.log('  ✅ Device-specific wizard execution');
     console.log('  ✅ Real-time device testing and connection validation');
+    console.log('  ✅ Kasa device auto-discovery regression coverage');
 
   } catch (error) {
     console.error('❌ Advanced test failed:', error.message);


### PR DESCRIPTION
## Summary
- update the Kasa wizard discovery step to import tplink-smarthome-api using an interop-safe pattern
- guard against missing Client constructors by returning a descriptive failure response
- extend the advanced wizard test script with a regression check that exercises the Kasa auto-discovery path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e076b8910c832ba95205842062675b