### PR TITLE
Refine wizard endpoint registration and response contracts

### DIFF
--- a/server-charlie.js
+++ b/server-charlie.js
@@ -3994,21 +3994,6 @@ app.use((error, req, res, next) => {
 });
 
 // Setup wizard endpoints - triggered when devices are identified
-app.get('/setup/wizards/:wizardId', async (req, res) => {
-  const { wizardId } = req.params;
-  try {
-    const wizard = await getSetupWizard(wizardId);
-    if (!wizard) {
-      return res.status(404).json({ error: 'Wizard not found' });
-    }
-    res.json(wizard);
-  } catch (error) {
-    console.error('Failed to load setup wizard:', error);
-    res.status(500).json({ error: 'Failed to load setup wizard' });
-  }
-});
-
-// Get all available setup wizards
 app.get('/setup/wizards', async (req, res) => {
   try {
     const wizards = await getAllSetupWizards();
@@ -4036,9 +4021,10 @@ app.get('/setup/wizards/:wizardId', async (req, res) => {
     });
   } catch (error) {
     console.error(`Error fetching wizard ${req.params.wizardId}:`, error);
-    res.status(404).json({
+    const isUnknownWizard = /Unknown wizard/i.test(error?.message || '');
+    res.status(isUnknownWizard ? 404 : 500).json({
       success: false,
-      error: error.message
+      error: isUnknownWizard ? 'Wizard not found' : error.message
     });
   }
 });
@@ -4619,111 +4605,15 @@ app.post('/setup/wizards/:wizardId/execute-validated', async (req, res) => {
   }
 });
 
-// 404 handler for undefined routes
+// 404 handler for undefined routes (must be registered last)
 app.use((req, res) => {
   console.warn(`⚠️  404 Not Found: ${req.method} ${req.url}`);
   res.status(404).json({
+    success: false,
     error: 'Not Found',
     message: `Route ${req.method} ${req.url} not found`,
     timestamp: new Date().toISOString()
   });
-});
-
-// Get wizard execution status
-app.get('/setup/wizards/:wizardId/status', async (req, res) => {
-  try {
-    const { wizardId } = req.params;
-    const status = await getWizardStatus(wizardId);
-    
-    if (!status.exists) {
-      return res.status(404).json({
-        success: false,
-        error: 'Wizard not found or never started'
-      });
-    }
-    
-    res.json({
-      success: true,
-      status
-    });
-  } catch (error) {
-    console.error(`Error getting wizard status ${req.params.wizardId}:`, error);
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
-  }
-});
-
-// Reset wizard state (useful for testing)
-app.delete('/setup/wizards/:wizardId', async (req, res) => {
-  try {
-    const { wizardId } = req.params;
-    wizardStates.delete(wizardId);
-    console.log(`🗑️ Reset wizard state for ${wizardId}`);
-    res.json({
-      success: true,
-      message: `Wizard ${wizardId} state reset`
-    });
-  } catch (error) {
-    console.error(`Error resetting wizard ${req.params.wizardId}:`, error);
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
-  }
-});
-
-// Automatically suggest wizards for discovered devices
-app.post('/discovery/suggest-wizards', async (req, res) => {
-  try {
-    const { devices } = req.body;
-    if (!Array.isArray(devices)) {
-      return res.status(400).json({
-        success: false,
-        error: 'devices array is required'
-      });
-    }
-    
-    const suggestions = [];
-    
-    for (const device of devices) {
-      // Find applicable wizards for this device type
-      const applicableWizards = Object.values(SETUP_WIZARDS).filter(wizard => 
-        wizard.targetDevices.includes(device.type) || 
-        device.services?.some(service => wizard.targetDevices.includes(service))
-      );
-      
-      if (applicableWizards.length > 0) {
-        suggestions.push({
-          device: {
-            ip: device.ip,
-            hostname: device.hostname,
-            type: device.type,
-            services: device.services
-          },
-          recommendedWizards: applicableWizards.map(w => ({
-            id: w.id,
-            name: w.name,
-            description: w.description,
-            confidence: calculateWizardConfidence(device, w)
-          })).sort((a, b) => b.confidence - a.confidence)
-        });
-      }
-    }
-    
-    res.json({
-      success: true,
-      suggestions
-    });
-    
-  } catch (error) {
-    console.error('Error suggesting wizards:', error);
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
-  }
 });
 
 // Start the server after all routes are defined

--- a/test-advanced-wizards.cjs
+++ b/test-advanced-wizards.cjs
@@ -52,6 +52,7 @@ async function testAdvancedWizardSystem() {
     console.log('📋 Test 1: Getting available wizard templates...');
     const templatesResponse = await makeRequest('GET', '/setup/templates');
     console.log(`Status: ${templatesResponse.status}`);
+    console.log(`Success: ${templatesResponse.data.success}`);
     if (templatesResponse.data.templates) {
       console.log('Available templates:');
       templatesResponse.data.templates.forEach(t => {
@@ -88,6 +89,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${recommendResponse.status}`);
+    console.log(`Success: ${recommendResponse.data.success}`);
     if (recommendResponse.data.recommendations) {
       const rec = recommendResponse.data.recommendations;
       console.log(`Individual wizards: ${rec.individualWizards.length}`);
@@ -114,6 +116,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${applyResponse.status}`);
+    console.log(`Success: ${applyResponse.data.success}`);
     if (applyResponse.data.result) {
       const result = applyResponse.data.result;
       console.log(`Template: ${result.templateName}`);
@@ -139,6 +142,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${validatedResponse.status}`);
+    console.log(`Success: ${validatedResponse.data.success}`);
     if (validatedResponse.data.result) {
       console.log(`Success: ${validatedResponse.data.result.success}`);
       if (validatedResponse.data.result.message) {
@@ -159,6 +163,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${invalidResponse.status}`);
+    console.log(`Success: ${invalidResponse.data.success}`);
     if (invalidResponse.data.errors) {
       console.log(`Validation errors: ${invalidResponse.data.errors.length}`);
       invalidResponse.data.errors.forEach(error => {
@@ -174,6 +179,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${bulkResponse.status}`);
+    console.log(`Success: ${bulkResponse.data.success}`);
     if (bulkResponse.data.result) {
       const result = bulkResponse.data.result;
       console.log(`Operation: ${result.operation}`);
@@ -196,6 +202,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${mqttResponse.status}`);
+    console.log(`Success: ${mqttResponse.data.success}`);
     if (mqttResponse.data.result) {
       console.log(`Success: ${mqttResponse.data.result.success}`);
       if (mqttResponse.data.result.message) {
@@ -218,6 +225,7 @@ async function testAdvancedWizardSystem() {
     });
     
     console.log(`Status: ${topicResponse.status}`);
+    console.log(`Success: ${topicResponse.data.success}`);
     if (topicResponse.data.result) {
       console.log(`Success: ${topicResponse.data.result.success}`);
       if (topicResponse.data.result.data?.discoveredTopics) {

--- a/test-wizard-system.js
+++ b/test-wizard-system.js
@@ -52,6 +52,7 @@ async function testWizardSystem() {
     console.log('📋 Test 1: Getting all available wizards...');
     const wizardsResponse = await makeRequest('GET', '/setup/wizards');
     console.log(`Status: ${wizardsResponse.status}`);
+    console.log(`Success: ${wizardsResponse.data.success}`);
     console.log('Available wizards:');
     if (wizardsResponse.data.wizards) {
       wizardsResponse.data.wizards.forEach(w => {
@@ -64,6 +65,7 @@ async function testWizardSystem() {
     console.log('🎯 Test 2: Getting MQTT wizard definition...');
     const mqttWizardResponse = await makeRequest('GET', '/setup/wizards/mqtt-setup');
     console.log(`Status: ${mqttWizardResponse.status}`);
+    console.log(`Success: ${mqttWizardResponse.data.success}`);
     if (mqttWizardResponse.data.wizard) {
       const wizard = mqttWizardResponse.data.wizard;
       console.log(`Wizard: ${wizard.name}`);
@@ -89,6 +91,7 @@ async function testWizardSystem() {
       data: stepData
     });
     console.log(`Status: ${executeResponse.status}`);
+    console.log(`Success: ${executeResponse.data.success}`);
     if (executeResponse.data.result) {
       console.log(`Success: ${executeResponse.data.result.success}`);
       console.log(`Next step: ${executeResponse.data.result.nextStep}`);
@@ -99,6 +102,7 @@ async function testWizardSystem() {
     console.log('📊 Test 4: Checking wizard execution status...');
     const statusResponse = await makeRequest('GET', '/setup/wizards/mqtt-setup/status');
     console.log(`Status: ${statusResponse.status}`);
+    console.log(`Success: ${statusResponse.data.success}`);
     if (statusResponse.data.status) {
       const status = statusResponse.data.status;
       console.log(`Progress: ${status.progress}% (${status.currentStep}/${status.totalSteps})`);
@@ -128,6 +132,7 @@ async function testWizardSystem() {
       devices: testDevices
     });
     console.log(`Status: ${suggestResponse.status}`);
+    console.log(`Success: ${suggestResponse.data.success}`);
     if (suggestResponse.data.suggestions) {
       console.log('Wizard suggestions:');
       suggestResponse.data.suggestions.forEach(suggestion => {


### PR DESCRIPTION
## Summary
- remove the duplicate wizard route definitions registered after the 404 middleware and ensure each endpoint is declared once
- ensure wizard endpoints return the `{ success, ... }` envelope and keep the 404 middleware as the final handler
- update the wizard request test scripts to log the new success flag returned by each endpoint

## Testing
- not run (requires the server process to be running to exercise the request scripts)


------
https://chatgpt.com/codex/tasks/task_e_68e076b02fac832b93c0c68ab871777b