### PR TITLE
Add device assignment workflow to Device Manager

### DIFF
--- a/frontend/src/components/DeviceManager.tsx
+++ b/frontend/src/components/DeviceManager.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from "react";
-import { Device, useDevices } from "../store/devices";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Device, DeviceAssignment, useDevices } from "../store/devices";
 
 const PROTOCOL_ORDER = ["kasa", "mqtt", "switchbot", "other"] as const;
 
@@ -38,12 +38,262 @@ const filterDevices = (devices: Device[], protocolFilter: string, search: string
     });
 };
 
+type ToastOptions = {
+  title?: string;
+  msg?: string;
+  kind?: string;
+  icon?: string;
+};
+
+const emitToast = (options: ToastOptions, ttlMs?: number) => {
+  if (typeof window !== "undefined" && typeof (window as Record<string, unknown>).showToast === "function") {
+    (window as { showToast: (opts: ToastOptions, ttl?: number) => void }).showToast(options, ttlMs);
+  }
+};
+
+interface RoomOption {
+  id: string;
+  name: string;
+}
+
+interface EquipmentOption {
+  id: string;
+  label: string;
+  category?: string;
+}
+
+const normalizeRoom = (room: unknown, index: number): RoomOption => {
+  if (!room || typeof room !== "object") {
+    return { id: `room-${index + 1}`, name: `Room ${index + 1}` };
+  }
+  const source = room as Record<string, unknown>;
+  const idRaw = typeof source.id === "string" && source.id.trim().length > 0 ? source.id.trim() : null;
+  const nameRaw = typeof source.name === "string" && source.name.trim().length > 0 ? source.name.trim() : null;
+  const fallback = `room-${index + 1}`;
+  return {
+    id: idRaw || fallback,
+    name: nameRaw || idRaw || fallback,
+  };
+};
+
+const normalizeEquipment = (item: unknown, index: number): EquipmentOption => {
+  if (!item || typeof item !== "object") {
+    const fallback = `equipment-${index + 1}`;
+    return { id: fallback, label: fallback };
+  }
+  const source = item as Record<string, unknown>;
+  const vendor = typeof source.vendor === "string" ? source.vendor : "";
+  const model = typeof source.model === "string" ? source.model : "";
+  const category = typeof source.category === "string" ? source.category : undefined;
+  const readable = [vendor, model].filter(Boolean).join(" ").trim() || `Equipment ${index + 1}`;
+  const fallbackId = readable.toLowerCase().replace(/[^a-z0-9]+/gi, "-") || `equipment-${index + 1}`;
+  const id = typeof source.id === "string" && source.id.trim().length > 0 ? source.id.trim() : fallbackId;
+  const label = category ? `${readable} (${category})` : readable;
+  return { id, label, category };
+};
+
 export const DeviceManager: React.FC = () => {
-  const { devices, loading, error, refresh } = useDevices();
+  const { devices, loading, error, refresh, assignDevice, unassignDevice } = useDevices();
   const [protocolFilter, setProtocolFilter] = useState<string>("all");
   const [search, setSearch] = useState<string>("");
+  const [rooms, setRooms] = useState<RoomOption[]>([]);
+  const [equipment, setEquipment] = useState<EquipmentOption[]>([]);
+  const [expanded, setExpanded] = useState<string[]>([]);
+  const [assignmentDrafts, setAssignmentDrafts] = useState<Record<string, DeviceAssignment>>({});
+  const [pending, setPending] = useState<Set<string>>(new Set());
 
-  const filteredDevices = useMemo(() => filterDevices(devices, protocolFilter, search), [devices, protocolFilter, search]);
+  useEffect(() => {
+    setAssignmentDrafts(() => {
+      const next: Record<string, DeviceAssignment> = {};
+      devices.forEach((device) => {
+        next[device.device_id] = {
+          roomId: device.assignedEquipment?.roomId ?? null,
+          equipmentId: device.assignedEquipment?.equipmentId ?? null,
+        };
+      });
+      return next;
+    });
+  }, [devices]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadRooms = async () => {
+      try {
+        const response = await fetch("/farm");
+        if (!response.ok) {
+          throw new Error(`Failed to load rooms (${response.status})`);
+        }
+        const data = (await response.json()) as {
+          rooms?: unknown[];
+          farm?: { rooms?: unknown[] };
+        };
+        const rawRooms = Array.isArray(data.rooms)
+          ? data.rooms
+          : Array.isArray(data.farm?.rooms)
+          ? data.farm?.rooms
+          : [];
+        if (!cancelled) {
+          const normalized = (rawRooms as unknown[]).map((room, index) => normalizeRoom(room, index));
+          const unique = normalized.filter(
+            (room, index, arr) => arr.findIndex((candidate) => candidate.id === room.id) === index
+          );
+          setRooms(unique);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setRooms([]);
+        }
+      }
+    };
+
+    const loadEquipment = async () => {
+      try {
+        const response = await fetch("/data/equipment-kb.json");
+        if (!response.ok) {
+          throw new Error(`Failed to load equipment (${response.status})`);
+        }
+        const data = (await response.json()) as { equipment?: unknown[] };
+        const rawEquipment = Array.isArray(data.equipment) ? data.equipment : [];
+        if (!cancelled) {
+          const normalized = (rawEquipment as unknown[]).map((item, index) => normalizeEquipment(item, index));
+          const deduped = normalized.filter(
+            (item, index, arr) => arr.findIndex((candidate) => candidate.id === item.id) === index
+          );
+          deduped.sort((a, b) => a.label.localeCompare(b.label));
+          setEquipment(deduped);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setEquipment([]);
+        }
+      }
+    };
+
+    loadRooms();
+    loadEquipment();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filteredDevices = useMemo(
+    () => filterDevices(devices, protocolFilter, search),
+    [devices, protocolFilter, search]
+  );
+
+  const roomLookup = useMemo(() => {
+    return rooms.reduce<Record<string, RoomOption>>((acc, room) => {
+      acc[room.id] = room;
+      return acc;
+    }, {});
+  }, [rooms]);
+
+  const equipmentLookup = useMemo(() => {
+    return equipment.reduce<Record<string, EquipmentOption>>((acc, item) => {
+      acc[item.id] = item;
+      return acc;
+    }, {});
+  }, [equipment]);
+
+  const isExpanded = useCallback(
+    (deviceId: string) => expanded.includes(deviceId),
+    [expanded]
+  );
+
+  const toggleExpanded = useCallback((deviceId: string) => {
+    setExpanded((prev) =>
+      prev.includes(deviceId) ? prev.filter((id) => id !== deviceId) : [...prev, deviceId]
+    );
+  }, []);
+
+  const setDraft = useCallback((deviceId: string, draft: DeviceAssignment) => {
+    setAssignmentDrafts((prev) => ({ ...prev, [deviceId]: draft }));
+  }, []);
+
+  const setPendingState = useCallback((deviceId: string, value: boolean) => {
+    setPending((prev) => {
+      const next = new Set(prev);
+      if (value) {
+        next.add(deviceId);
+      } else {
+        next.delete(deviceId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSubmitAssignment = useCallback(
+    async (device: Device) => {
+      const draft = assignmentDrafts[device.device_id] ?? {
+        roomId: null,
+        equipmentId: null,
+      };
+      if (!draft.roomId || !draft.equipmentId) {
+        emitToast({
+          title: "Assignment required",
+          msg: "Select both a room and equipment to assign this device.",
+          kind: "warn",
+          icon: "⚠️",
+        });
+        throw new Error("Room and equipment are required");
+      }
+      setPendingState(device.device_id, true);
+      try {
+        const updated = await assignDevice(device.device_id, draft);
+        const roomName = updated.assignedEquipment.roomId
+          ? roomLookup[updated.assignedEquipment.roomId]?.name || updated.assignedEquipment.roomId
+          : "room";
+        const equipmentName = updated.assignedEquipment.equipmentId
+          ? equipmentLookup[updated.assignedEquipment.equipmentId]?.label || updated.assignedEquipment.equipmentId
+          : "equipment";
+        emitToast({
+          title: "Assignment saved",
+          msg: `${updated.name} mapped to ${equipmentName} in ${roomName}.`,
+          kind: "success",
+          icon: "✅",
+        });
+        toggleExpanded(device.device_id);
+      } catch (err) {
+        emitToast({
+          title: "Assignment failed",
+          msg: err instanceof Error ? err.message : String(err),
+          kind: "warn",
+          icon: "⚠️",
+        });
+        throw err;
+      } finally {
+        setPendingState(device.device_id, false);
+      }
+    },
+    [assignmentDrafts, assignDevice, equipmentLookup, roomLookup, setPendingState, toggleExpanded]
+  );
+
+  const handleUnassign = useCallback(
+    async (device: Device) => {
+      setPendingState(device.device_id, true);
+      try {
+        await unassignDevice(device.device_id);
+        emitToast({
+          title: "Device unassigned",
+          msg: `${device.name} is now unassigned.`,
+          kind: "info",
+          icon: "ℹ️",
+        });
+      } catch (err) {
+        emitToast({
+          title: "Unassign failed",
+          msg: err instanceof Error ? err.message : String(err),
+          kind: "warn",
+          icon: "⚠️",
+        });
+      } finally {
+        setPendingState(device.device_id, false);
+      }
+    },
+    [setPendingState, unassignDevice]
+  );
 
   return (
     <section className="device-manager">
@@ -75,42 +325,166 @@ export const DeviceManager: React.FC = () => {
       {!loading && filteredDevices.length === 0 && <p className="device-manager__empty">No devices match the current filters.</p>}
 
       <div className="device-manager__grid">
-        {filteredDevices.map((device) => (
-          <article key={device.device_id} className="device-card" data-protocol={device.protocol}>
-            <header className="device-card__header">
-              <h3>{device.name}</h3>
-              <span className={`device-card__status device-card__status--${device.online ? "online" : "offline"}`}>
-                {device.online ? "Online" : "Offline"}
-              </span>
-            </header>
-            <dl className="device-card__meta">
-              <div>
-                <dt>Type</dt>
-                <dd>{device.category}</dd>
+        {filteredDevices.map((device) => {
+          const assignment = assignmentDrafts[device.device_id] ?? {
+            roomId: device.assignedEquipment?.roomId ?? null,
+            equipmentId: device.assignedEquipment?.equipmentId ?? null,
+          };
+          const expandedForDevice = isExpanded(device.device_id);
+          const pendingForDevice = pending.has(device.device_id);
+          const assignedRoomName = device.assignedEquipment?.roomId
+            ? roomLookup[device.assignedEquipment.roomId]?.name || device.assignedEquipment.roomId
+            : null;
+          const assignedEquipmentName = device.assignedEquipment?.equipmentId
+            ? equipmentLookup[device.assignedEquipment.equipmentId]?.label || device.assignedEquipment.equipmentId
+            : null;
+          const assignmentSummary = (() => {
+            if (assignedRoomName && assignedEquipmentName) {
+              return `Assigned to ${assignedEquipmentName} in ${assignedRoomName}`;
+            }
+            if (assignedRoomName) {
+              return `Assigned to ${assignedRoomName}`;
+            }
+            if (assignedEquipmentName) {
+              return `Assigned to ${assignedEquipmentName}`;
+            }
+            return "Not yet assigned";
+          })();
+
+          const handleRoomChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+            const value = event.target.value || null;
+            setDraft(device.device_id, {
+              roomId: value,
+              equipmentId: assignment.equipmentId,
+            });
+          };
+
+          const handleEquipmentChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+            const value = event.target.value || null;
+            setDraft(device.device_id, {
+              roomId: assignment.roomId,
+              equipmentId: value,
+            });
+          };
+
+          const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            try {
+              await handleSubmitAssignment(device);
+            } catch {
+              // handled via toast
+            }
+          };
+
+          return (
+            <article key={device.device_id} className="device-card" data-protocol={device.protocol}>
+              <header className="device-card__header">
+                <h3>{device.name}</h3>
+                <span className={`device-card__status device-card__status--${device.online ? "online" : "offline"}`}>
+                  {device.online ? "Online" : "Offline"}
+                </span>
+              </header>
+              <dl className="device-card__meta">
+                <div>
+                  <dt>Type</dt>
+                  <dd>{device.category}</dd>
+                </div>
+                <div>
+                  <dt>Protocol</dt>
+                  <dd>{protocolLabel(device.protocol)}</dd>
+                </div>
+                <div>
+                  <dt>Identifier</dt>
+                  <dd>{device.device_id}</dd>
+                </div>
+              </dl>
+              {Object.keys(device.capabilities).length > 0 && (
+                <div className="device-card__capabilities">
+                  <h4>Capabilities</h4>
+                  <ul>
+                    {Object.entries(device.capabilities).map(([key, value]) => (
+                      <li key={key}>
+                        <strong>{key}:</strong> {String(value)}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              <div className="device-manager__assignment">
+                <div className="device-manager__assignment-summary">
+                  <span>{assignmentSummary}</span>
+                  <div className="device-manager__assignment-actions">
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(device.device_id)}
+                      className="ghost"
+                      disabled={pendingForDevice}
+                    >
+                      {expandedForDevice ? "Close" : "Assign"}
+                    </button>
+                    {(device.assignedEquipment?.roomId || device.assignedEquipment?.equipmentId) && (
+                      <button
+                        type="button"
+                        className="ghost"
+                        onClick={() => handleUnassign(device)}
+                        disabled={pendingForDevice}
+                      >
+                        Unassign
+                      </button>
+                    )}
+                  </div>
+                </div>
+                {expandedForDevice && (
+                  rooms.length > 0 && equipment.length > 0 ? (
+                    <form className="device-manager__assign-form" onSubmit={handleSubmit}>
+                      <label>
+                        Room
+                        <select value={assignment.roomId ?? ""} onChange={handleRoomChange} required>
+                          <option value="">Select room</option>
+                          {rooms.map((room) => (
+                            <option key={room.id} value={room.id}>
+                              {room.name}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label>
+                        Equipment
+                        <select value={assignment.equipmentId ?? ""} onChange={handleEquipmentChange} required>
+                          <option value="">Select equipment</option>
+                          {equipment.map((item) => (
+                            <option key={item.id} value={item.id}>
+                              {item.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <div className="device-manager__assign-form-actions">
+                        <button type="submit" className="primary" disabled={pendingForDevice}>
+                          Save assignment
+                        </button>
+                        <button
+                          type="button"
+                          className="ghost"
+                          onClick={() => toggleExpanded(device.device_id)}
+                          disabled={pendingForDevice}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </form>
+                  ) : (
+                    <div className="device-manager__assign-form device-manager__assign-form--empty">
+                      <p className="tiny">
+                        Add rooms and equipment data to enable assignments.
+                      </p>
+                    </div>
+                  )
+                )}
               </div>
-              <div>
-                <dt>Protocol</dt>
-                <dd>{protocolLabel(device.protocol)}</dd>
-              </div>
-              <div>
-                <dt>Identifier</dt>
-                <dd>{device.device_id}</dd>
-              </div>
-            </dl>
-            {Object.keys(device.capabilities).length > 0 && (
-              <div className="device-card__capabilities">
-                <h4>Capabilities</h4>
-                <ul>
-                  {Object.entries(device.capabilities).map(([key, value]) => (
-                    <li key={key}>
-                      <strong>{key}:</strong> {String(value)}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          </article>
-        ))}
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/frontend/src/store/devices.ts
+++ b/frontend/src/store/devices.ts
@@ -2,6 +2,11 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 
 export type DeviceProtocol = "kasa" | "mqtt" | "switchbot" | "other";
 
+export interface DeviceAssignment {
+  roomId: string | null;
+  equipmentId: string | null;
+}
+
 export interface Device {
   device_id: string;
   name: string;
@@ -10,6 +15,7 @@ export interface Device {
   online: boolean;
   capabilities: Record<string, unknown>;
   details: Record<string, unknown>;
+  assignedEquipment: DeviceAssignment;
 }
 
 interface DeviceContextValue {
@@ -17,9 +23,73 @@ interface DeviceContextValue {
   loading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
+  assignDevice: (deviceId: string, assignment: DeviceAssignment) => Promise<Device>;
+  unassignDevice: (deviceId: string) => Promise<Device>;
 }
 
 const DeviceContext = createContext<DeviceContextValue | undefined>(undefined);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const normalizeAssignment = (value: unknown): DeviceAssignment => {
+  if (!isRecord(value)) {
+    return { roomId: null, equipmentId: null };
+  }
+  const roomId = typeof value.roomId === "string" ? value.roomId : typeof value.room === "string" ? value.room : null;
+  const equipmentId =
+    typeof value.equipmentId === "string"
+      ? value.equipmentId
+      : typeof value.equipment === "string"
+      ? value.equipment
+      : null;
+  return {
+    roomId: roomId && roomId.length > 0 ? roomId : null,
+    equipmentId: equipmentId && equipmentId.length > 0 ? equipmentId : null,
+  };
+};
+
+const normalizeDevice = (raw: unknown): Device => {
+  const source = isRecord(raw) ? raw : {};
+  const rawId =
+    typeof source.device_id === "string" && source.device_id.trim().length > 0
+      ? source.device_id.trim()
+      : typeof source.id === "string" && source.id.trim().length > 0
+      ? source.id.trim()
+      : "";
+  const rawName =
+    typeof source.name === "string" && source.name.trim().length > 0
+      ? source.name.trim()
+      : typeof source.deviceName === "string" && source.deviceName.trim().length > 0
+      ? source.deviceName.trim()
+      : rawId;
+  const rawCategory =
+    typeof source.category === "string" && source.category.trim().length > 0
+      ? source.category.trim()
+      : typeof source.type === "string" && source.type.trim().length > 0
+      ? source.type.trim()
+      : "device";
+  const protocol =
+    typeof source.protocol === "string" && source.protocol.trim().length > 0
+      ? source.protocol.trim().toLowerCase()
+      : typeof source.transport === "string" && source.transport.trim().length > 0
+      ? source.transport.trim().toLowerCase()
+      : "other";
+  const online = typeof source.online === "boolean" ? source.online : Boolean(source.online);
+  const capabilities = isRecord(source.capabilities) ? source.capabilities : {};
+  const details = isRecord(source.details) ? source.details : {};
+
+  return {
+    device_id: rawId,
+    name: rawName,
+    category: rawCategory,
+    protocol: protocol || "other",
+    online,
+    capabilities,
+    details,
+    assignedEquipment: normalizeAssignment(source.assignedEquipment),
+  };
+};
 
 export const DeviceProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [devices, setDevices] = useState<Device[]>([]);
@@ -34,14 +104,55 @@ export const DeviceProvider: React.FC<React.PropsWithChildren> = ({ children }) 
       if (!response.ok) {
         throw new Error(`Failed to load devices (${response.status})`);
       }
-      const payload: Device[] = await response.json();
-      setDevices(payload);
+      const payload = await response.json();
+      const list = Array.isArray(payload?.devices) ? payload.devices : Array.isArray(payload) ? payload : [];
+      setDevices(list.map((item) => normalizeDevice(item)));
     } catch (err) {
       setError((err as Error).message);
     } finally {
       setLoading(false);
     }
   }, []);
+
+  const updateAssignment = useCallback(
+    async (deviceId: string, assignment: DeviceAssignment): Promise<Device> => {
+      try {
+        const response = await fetch(`/devices/${encodeURIComponent(deviceId)}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ assignedEquipment: assignment }),
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to update assignment (${response.status})`);
+        }
+        const body = await response
+          .json()
+          .catch(() => ({ device: { device_id: deviceId, assignedEquipment: assignment } }));
+        const updated = normalizeDevice((body as Record<string, unknown>)?.device ?? body);
+        setDevices((prev) => {
+          const next = prev.map((device) => (device.device_id === updated.device_id ? updated : device));
+          if (next.some((device) => device.device_id === updated.device_id)) {
+            return next;
+          }
+          return [...next, updated];
+        });
+        return updated;
+      } catch (err) {
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+    },
+    [setDevices]
+  );
+
+  const assignDevice = useCallback(
+    (deviceId: string, assignment: DeviceAssignment) => updateAssignment(deviceId, assignment),
+    [updateAssignment]
+  );
+
+  const unassignDevice = useCallback(
+    (deviceId: string) => updateAssignment(deviceId, { roomId: null, equipmentId: null }),
+    [updateAssignment]
+  );
 
   useEffect(() => {
     refresh();
@@ -53,8 +164,10 @@ export const DeviceProvider: React.FC<React.PropsWithChildren> = ({ children }) 
       loading,
       error,
       refresh,
+      assignDevice,
+      unassignDevice,
     }),
-    [devices, loading, error, refresh]
+    [devices, loading, error, refresh, assignDevice, unassignDevice]
   );
 
   return <DeviceContext.Provider value={value}>{children}</DeviceContext.Provider>;

--- a/public/styles.charlie.css
+++ b/public/styles.charlie.css
@@ -1804,26 +1804,107 @@ input[type="range"]#grd {
 }
 
 .device-manager__assignment {
-  margin-top: 4px;
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: 1px solid var(--gr-border, #E5E7EB);
+  padding-top: 12px;
+}
+
+.device-manager__assignment-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 0.875rem;
+  color: var(--medium, #64748b);
+}
+
+.device-manager__assignment-summary span {
+  font-weight: 500;
+  color: var(--dark, #0f172a);
+}
+
+.device-manager__assignment-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .device-manager__assign-form {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: flex-end;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  align-items: end;
   background: var(--gr-bg, #f8fafc);
-  padding: 10px;
-  border-radius: 8px;
+  padding: 12px;
+  border-radius: 10px;
   border: 1px solid var(--gr-border, #E5E7EB);
 }
 
 .device-manager__assign-form label {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   font-size: 0.75rem;
-  color: var(--medium);
+  color: var(--medium, #64748b);
+}
+
+.device-manager__assign-form select,
+.device-manager__assign-form input,
+.device-manager__assign-form button {
+  width: 100%;
+}
+
+.device-manager__assign-form select,
+.device-manager__assign-form input {
+  border-radius: 8px;
+  border: 1px solid var(--gr-border, #E5E7EB);
+  padding: 8px;
+  font-size: 0.875rem;
+  background: #fff;
+  color: var(--dark, #0f172a);
+}
+
+.device-manager__assign-form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.device-manager__assign-form--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--gr-bg, #f8fafc);
+  border: 1px dashed var(--gr-border, #E5E7EB);
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.device-manager__assign-form--empty p {
+  margin: 0;
+  color: var(--medium, #64748b);
+}
+
+@media (max-width: 720px) {
+  .device-manager__assign-form {
+    grid-template-columns: 1fr;
+  }
+
+  .device-manager__assignment-summary {
+    align-items: flex-start;
+  }
+
+  .device-manager__assignment-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
 }
 
 .device-manager__footer {


### PR DESCRIPTION
## Summary
- normalize device documents on the API to expose assignment metadata and defaults
- teach the devices store to parse API payloads, normalize records, and expose assignment helpers
- expand the Device Manager UI with room/equipment assignment controls and updated styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e05da5d2f0832bb076e7cdd28671c0