### PR TITLE
Fix setup lights showing in ungrouped list

### DIFF
--- a/public/app.charlie.js
+++ b/public/app.charlie.js
@@ -8664,22 +8664,32 @@ function wireGlobalEvents() {
         const groupZoneSel = document.getElementById('groupZoneDropdown');
         let setupLights = [];
         if (groupRoomSel && groupZoneSel && window.STATE?.lightSetups) {
-          const roomId = groupRoomSel.value;
-          const zone = groupZoneSel.value;
+          const roomVal = groupRoomSel.value;
+          const zoneVal = groupZoneSel.value;
+          const roomObj = (window.STATE?.rooms||[]).find(r => r.id === roomVal || r.name === roomVal);
+          const roomId = roomObj?.id || roomVal;
+          const roomName = roomObj?.name || roomVal;
           window.STATE.lightSetups.forEach(setup => {
-            if ((setup.room === roomId || setup.room === (window.STATE?.rooms?.find(r=>r.id===roomId)?.name)) && setup.zone === zone) {
+            const setupRoomObj = (window.STATE?.rooms||[]).find(r => r.id === setup.room || r.name === setup.room);
+            const setupRoomId = setupRoomObj?.id || setup.room;
+            const setupRoomName = setupRoomObj?.name || setup.room;
+            const matchesRoom = (setupRoomId && setupRoomId === roomId) || (setupRoomName && setupRoomName === roomName);
+            const matchesZone = String(setup.zone || '') === String(zoneVal || '');
+            if (matchesRoom && matchesZone) {
               if (Array.isArray(setup.fixtures)) {
                 setup.fixtures.forEach(f => {
                   // Synthesize a device-like object for ungrouped display
-                  if (!assigned.has(f.id)) {
+                  const synthId = f.id || `wired-${(f.vendor||f.name||'').replace(/\s+/g,'_')}-${(f.model||'').replace(/\s+/g,'_')}`;
+                  if (!assigned.has(synthId)) {
                     setupLights.push({
-                      id: f.id,
+                      id: synthId,
                       deviceName: f.vendor ? `${f.vendor} ${f.model}` : (f.name || f.model || 'Light'),
                       type: 'light',
                       watts: f.watts,
                       count: f.count,
                       source: 'setup',
-                      // Add more fields as needed
+                      vendor: f.vendor,
+                      model: f.model
                     });
                   }
                 });


### PR DESCRIPTION
## Summary
- normalise room and zone matching when pulling setup fixtures for the group card
- generate stable synthetic IDs for setup fixtures so they appear in the ungrouped lights list and carry vendor/model metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e457ffaf00832b86f32e8e8f6794b0