### PR TITLE
Enhance group card plan and light summaries

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -520,6 +520,35 @@
             <div id="groupSpectrumPreview" class="group-spectrum" aria-live="polite" style="margin:6px 0 8px"></div>
             <div id="groupSchedulePreview" class="schedule-preview schedule-preview--group" aria-live="polite"></div>
 
+            <div class="group-info-grid">
+              <section id="groupPlanInfoCard" class="group-info-card" aria-live="polite">
+                <header class="group-info-card__header">
+                  <div>
+                    <h3 id="groupPlanInfoTitle">Plan information</h3>
+                    <p id="groupPlanInfoSubtitle" class="tiny text-muted">Select a plan to view spectrum targets.</p>
+                  </div>
+                </header>
+                <div class="group-info-card__body">
+                  <canvas id="groupPlanInfoCanvas" class="group-info-card__canvas" width="320" height="100" role="img" aria-label="Plan spectrum preview"></canvas>
+                  <dl id="groupPlanInfoMetrics" class="group-info-card__metrics"></dl>
+                </div>
+              </section>
+
+              <section id="groupLightInfoCard" class="group-info-card" aria-live="polite">
+                <header class="group-info-card__header">
+                  <div>
+                    <h3 id="groupLightInfoTitle">Current mix</h3>
+                    <p id="groupLightInfoSubtitle" class="tiny text-muted">Add lights to preview live control options.</p>
+                  </div>
+                </header>
+                <div class="group-info-card__body">
+                  <canvas id="groupLightInfoCanvas" class="group-info-card__canvas" width="320" height="100" role="img" aria-label="Current spectrum preview"></canvas>
+                  <dl id="groupLightInfoMetrics" class="group-info-card__metrics"></dl>
+                  <p id="groupLightInfoMode" class="tiny text-muted" aria-live="polite"></p>
+                </div>
+              </section>
+            </div>
+
             <!-- Inline Group Schedule Editor (appears when editing a group's schedule) -->
             <div id="groupScheduleEditor" class="group-schedule-editor" style="display:none;margin-top:8px">
               <div class="row row--gap-sm row--center row--wrap">
@@ -569,7 +598,10 @@
             <div class="group-roster-card" id="ungroupedLightsCard">
               <div class="row row--between row--center mb-xs">
                 <h3 style="margin:0;font-size:15px;color:#0f172a">Ungrouped Lights</h3>
-                <span id="ungroupedStatus" class="tiny" aria-live="polite"></span>
+                <div class="row row--gap-xs row--center">
+                  <span id="ungroupedStatus" class="tiny" aria-live="polite"></span>
+                  <button id="btnImportFixtures" type="button" class="ghost tiny">Import fixtures</button>
+                </div>
               </div>
               <div id="ungroupedList" class="grid cols-3" aria-live="polite"></div>
               <p id="ungroupedEmpty" class="tiny" style="display:none">All lights are assigned to groups.</p>

--- a/public/styles.charlie.css
+++ b/public/styles.charlie.css
@@ -1828,6 +1828,87 @@ input[type="checkbox"] {
   font-weight: 500;
 }
 
+.group-info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin: 12px 0;
+}
+
+.group-info-card {
+  background: var(--gr-surface, #ffffff);
+  border: 1px solid var(--gr-border, #E5E7EB);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.group-info-card__header h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--dark, #0f172a);
+}
+
+.group-info-card__header p {
+  margin: 2px 0 0;
+}
+
+.group-info-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.group-info-card__canvas {
+  width: 100%;
+  height: 100px;
+  border-radius: 6px;
+  background: var(--gr-bg, #F8FAFC);
+}
+
+.group-info-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px 12px;
+  margin: 0;
+}
+
+.group-info-card__metrics dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+  margin: 0;
+}
+
+.group-info-card__metrics dd {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--dark, #0f172a);
+}
+
+.group-info-card.is-empty {
+  opacity: 0.7;
+}
+
+.group-info-card__body .tiny.text-muted {
+  margin-top: 0;
+}
+
+.group-hud-locked .kv,
+.group-hud-locked .kv input,
+.group-hud-locked .kv label,
+.group-hud-locked .kv span {
+  opacity: 0.55;
+}
+
+.group-hud-locked input:disabled {
+  cursor: not-allowed;
+}
+
 .group-roster-card {
   background: var(--gr-surface, white);
   border: 1px solid var(--gr-border, #E5E7EB);


### PR DESCRIPTION
## Summary
- add plan and current mix info cards to the Groups panel with spectrum previews and metrics
- lock spectrum sliders automatically when a group only contains static fixtures and expose an import fixtures shortcut
- refresh group cards when related setup data changes so rooms, light setups, and plans stay in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4f2e9e1e0832ba2f4d81e9e067849