### PR TITLE
Add preflight scale probe helper and operator quick test guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ The script checks:
 - GET /index.html
 - POST /data/device-meta.json (dry-run to temp file)
 
+### Operator quick test
+
+Before exercising Groups controls, run the combined preflight and scale probe helper:
+
+```bash
+./scripts/preflight-scale-probe.sh
+```
+
+The script executes the "preflight five" checks, validates CORS handling, and determines whether the controller expects `00-64` or `00-FF` channel scales. See [`docs/operator-quick-test.md`](docs/operator-quick-test.md) for details and manual follow-up steps.
+
 ### Pre-AI Automation Layer
 
 The pre-AI automation layer orchestrates smart plugs using real-time sensor data. It exposes REST endpoints on the primary Node.js server and persists telemetry for future ML training.

--- a/docs/operator-quick-test.md
+++ b/docs/operator-quick-test.md
@@ -1,0 +1,37 @@
+# Operator Quick Test
+
+This checklist combines the "preflight five" and the lighting scale probe into a repeatable workflow that operators can run before enabling **Groups** control in a new environment.
+
+## Scripted preflight
+
+Run the helper script from the repository root:
+
+```bash
+./scripts/preflight-scale-probe.sh
+```
+
+Environment variables:
+
+- `API_BASE` – Overrides the default target of `http://127.0.0.1:8091`.
+- `DEVICE_ID` – Device used for the scale probe (default `2`). Choose a single, easy-to-observe fixture for the verification pulse.
+
+The script performs four checks:
+
+1. `GET /healthz` — confirms the server is responding.
+2. `GET /api/devicedatas` — verifies that at least one device is visible from the controller. The raw payload is parsed server-side to catch schema drift.
+3. `OPTIONS /api/devicedatas` — sends a realistic CORS preflight (Origin + Access-Control-Request headers) and fails if the proxy does not echo `Access-Control-Allow-Origin` **and** `Access-Control-Allow-Headers`.
+4. Scale probe — tests both `00-FF` and `00-64` channel scales by issuing the documented payload to `/api/devicedatas/device/{id}`. The first `2xx` response wins, the result is printed, and the device is reset to OFF (`{"status":"off","value":null}`) for safety.
+
+If any step fails, the script exits non-zero. Resolve the issue before editing Groups or schedules.
+
+## Manual confirmations
+
+After the script succeeds:
+
+- Open the dashboard in a browser and run `console.log(window.API_BASE, window.USE_SHIM);` to ensure the UI is reading the runtime configuration instead of a hard-coded port.
+- Confirm there are no console errors or red network requests before proceeding to Groups.
+- If you have a reference mix (e.g., safe ON), re-run the probe scale in the UI using the discovered range to double-check brightness expectations.
+
+## Record the outcome
+
+Document the chosen scale and the device used for the probe in your site log. This avoids future drift between the UI, Recipe Bridge, and any downstream automation. The script output can be attached directly to the onboarding ticket for traceability.

--- a/scripts/preflight-scale-probe.sh
+++ b/scripts/preflight-scale-probe.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Combined preflight checklist and controller scale probe for Light Engine Charlie.
+# Usage:
+#   ./preflight-scale-probe.sh [base_url]
+# Environment variables:
+#   API_BASE   Override default base URL (http://127.0.0.1:8091).
+#   DEVICE_ID  Device ID to probe (default: 2).
+
+set -euo pipefail
+
+BASE_URL="${1:-${API_BASE:-http://127.0.0.1:8091}}"
+DEVICE_ID="${DEVICE_ID:-2}"
+
+PASS_ICON="✔"
+FAIL_ICON="✖"
+INFO_ICON="➜"
+
+print_header() {
+  echo "========================================"
+  echo "$1"
+  echo "========================================"
+}
+
+run_step() {
+  local name="$1"
+  shift
+  echo "${INFO_ICON} ${name}"
+  if "$@"; then
+    echo "  ${PASS_ICON} ${name}" && echo
+  else
+    echo "  ${FAIL_ICON} ${name}" && echo
+    return 1
+  fi
+}
+
+curl_json() {
+  local url="$1"
+  curl -sS "$url"
+}
+
+check_healthz() {
+  curl -fsS "$BASE_URL/healthz" >/dev/null
+}
+
+check_devicedata_count() {
+  local response
+  response=$(curl_json "$BASE_URL/api/devicedatas") || return 1
+  printf '%s' "$response" | python3 - <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError as exc:
+    print(f"Failed to decode JSON: {exc}")
+    sys.exit(1)
+
+count = len(payload.get("data", []))
+print(f"  Devices discovered: {count}")
+sys.exit(0 if count > 0 else 1)
+PY
+}
+
+check_options_preflight() {
+  local tmp
+  tmp=$(mktemp)
+  local status
+  status=$(curl -s -D "$tmp" -o /dev/null -w "%{http_code}" -X OPTIONS \
+    "$BASE_URL/api/devicedatas" \
+    -H 'Origin: http://localhost' \
+    -H 'Access-Control-Request-Method: PATCH' \
+    -H 'Access-Control-Request-Headers: content-type')
+  echo "  HTTP status: ${status}"
+  echo "  Response headers:"
+  sed 's/^/    /' "$tmp"
+  local allow_origin allow_headers
+  allow_origin=$(grep -i 'Access-Control-Allow-Origin' "$tmp" || true)
+  allow_headers=$(grep -i 'Access-Control-Allow-Headers' "$tmp" || true)
+  rm -f "$tmp"
+  [[ "${status}" =~ ^2 ]] && [[ -n "$allow_origin" ]] && [[ -n "$allow_headers" ]]
+}
+
+probe_scale() {
+  local endpoint="$BASE_URL/api/devicedatas/device/$DEVICE_ID"
+  local try_patch
+  try_patch() {
+    local payload="$1"
+    local label="$2"
+    local tmp status
+    tmp=$(mktemp)
+    status=$(curl -s -o "$tmp" -w "%{http_code}" -X PATCH "$endpoint" \
+      -H 'Content-Type: application/json' \
+      -d "${payload}")
+    local body
+    body=$(cat "$tmp")
+    rm -f "$tmp"
+    echo "  Attempt ${label}: status ${status}"
+    if [[ -n "$body" ]]; then
+      echo "    Body: ${body}"
+    fi
+    if [[ "$status" =~ ^2 ]]; then
+      echo "  ✔ Controller accepted scale ${label}"
+      echo "${label}"
+      return 0
+    fi
+    return 1
+  }
+
+  echo "  Probing controller scale using device ${DEVICE_ID}"
+  if result=$(try_patch '{"status":"on","value":"000000FF0000"}' '00-FF'); then
+    SCALE_CHOICE="$result"
+  elif result=$(try_patch '{"status":"on","value":"000000640000"}' '00-64'); then
+    SCALE_CHOICE="$result"
+  else
+    echo "  ✖ Controller rejected both scales"
+    return 1
+  fi
+
+  echo "  Selected scale: ${SCALE_CHOICE}"
+  echo "  Restoring device to OFF"
+  curl -s -o /dev/null -w "%{http_code}" -X PATCH "$endpoint" \
+    -H 'Content-Type: application/json' \
+    -d '{"status":"off","value":null}' >/dev/null
+  return 0
+}
+
+print_header "Light Engine Charlie – Preflight & Scale Probe"
+
+overall=0
+
+run_step "Server health" check_healthz || overall=1
+run_step "Device inventory" check_devicedata_count || overall=1
+run_step "CORS preflight" check_options_preflight || overall=1
+run_step "Controller scale probe" probe_scale || overall=1
+
+echo "Summary:"
+if [[ $overall -eq 0 ]]; then
+  echo "  ${PASS_ICON} All checks passed"
+else
+  echo "  ${FAIL_ICON} One or more checks failed"
+fi
+
+cat <<'NOTE'
+Next steps:
+  • Verify window.API_BASE in the browser console.
+  • Ensure no console errors appear before using Groups.
+NOTE
+
+exit $overall


### PR DESCRIPTION
## Summary
- add a reusable `preflight-scale-probe.sh` helper that runs the preflight checks and detects the controller channel scale
- document the workflow in a new Operator Quick Test guide and reference it from the README

## Testing
- not run (infrastructure unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5a434b250832b8a99d05e7a934379